### PR TITLE
fix(chat): fix bug and improves error handling

### DIFF
--- a/app/schemas/message_schema.py
+++ b/app/schemas/message_schema.py
@@ -5,13 +5,11 @@ from app.enums.message import MessageStatus, MessageType
 
 
 class MessageCreate(BaseModel):
-    sender_id: str
     content: str
 
     model_config = ConfigDict(
         json_schema_extra={
             "example": {
-                "sender_id": "68805dc7bf5491c521b0d31a",
                 "content": "hello",
             }
         }

--- a/app/websocket/websocket_manager.py
+++ b/app/websocket/websocket_manager.py
@@ -37,6 +37,7 @@ class WebsocketManager:
         Send a personal message to a recipient's active connections.
         """
         data = message.model_dump(mode="json")
+        chat_id = data.get("chat_id")
         async with self._lock:
             sockets = list(self.user_connections.get(recipient_id, set()))
         if not sockets:
@@ -44,7 +45,9 @@ class WebsocketManager:
             return
         for ws in sockets:
             try:
-                await ws.send_json({"type": "personal_message", "data": data})
+                await ws.send_json(
+                    {"type": "personal_message", "chat_id": chat_id, "data": data}
+                )
             except WebSocketException as e:
                 logger.error(
                     "Error sending personal message to %s: %s", recipient_id, e


### PR DESCRIPTION
- Now raises 404 on missing chat instead of continuing.
- Validates personal chat participants length and membership before sending.
- Caches the newly created message to Redis immediately after DB insert.
- Sets message_status = SENT before pushing via websockets.
- Sends to both recipient_id and the sender_id to sync across the sender's other devices.
- Keeps DB status updated to SENT.
- Payload now includes top-level chat_id for consistency with group broadcast shape
- Removed sender_id from the WS payload model to reflect that we use the authenticated user_id