### PR TITLE
feat(websocket): robust Redis-first load_chat with safe DB fallback +…

### DIFF
--- a/app/redis_client.py
+++ b/app/redis_client.py
@@ -54,6 +54,15 @@ def redis_user_chat_rooms_complete_key(user_id: str) -> str:
     return f"user_chats:{user_id}:complete"
 
 
+def redis_chat_messages_complete_count_key(chat_id: str) -> str:
+    """
+    Redis key storing the number of cached messages for a chat after a DB backfill
+    on initial load (no cursor). Used to distinguish between a truly small chat
+    and an incomplete cache due to expirations.
+    """
+    return f"chat_messages:{chat_id}:complete_count"
+
+
 async def close_redis_connections():
     """
     Close Redis connections on application shutdown


### PR DESCRIPTION
… backfill

- Detect incomplete Redis pages:
    - If any message hash in the first page is missing/expired, force DB fallback.
    - On initial load (no cursor), do NOT fallback just because the page is short unless a completeness marker indicates expirations.
- Add completeness marker:
    - Store chat_messages:{chat_id}:complete_count on initial DB backfill to record how many items were cached.
    - During subsequent initial loads, if Redis returns fewer items than complete_count, treat cache as expired and fallback to DB.
    - Refresh the marker's TTL on every new message cache to keep it aligned with message key TTLs during active chats.
- Improve DB fallback coverage:
    - Query both ObjectId(chat_id) and chat_id string in Mongo to handle legacy documents with string-stored chat_id.